### PR TITLE
Fix not to work callNumber function

### DIFF
--- a/src/android/CordovaCall.java
+++ b/src/android/CordovaCall.java
@@ -310,6 +310,9 @@ public class CordovaCall extends CordovaPlugin {
     private void callNumber() {
         try {
           Intent intent = new Intent(Intent.ACTION_CALL, Uri.fromParts("tel", realCallTo, null));
+          if (android.os.Build.VERSION.SDK_INT >= 28) {
+              intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+          }
           this.cordova.getActivity().getApplicationContext().startActivity(intent);
         } catch(Exception e) {
           this.callbackContext.error("Call Failed");


### PR DESCRIPTION
### Description

A below error is occurred when running callNumber function on Android 10.

> Exception android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?

### Cause

The error is caused by the issue below.

https://developer.android.com/about/versions/pie/android-9.0-changes-all#fant-required

### Solution

A below code was added.

```
          if (android.os.Build.VERSION.SDK_INT >= 28) {
              intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
          }
```

### Test

I confirmed that callNumber function is success on Android 10.  
I could check only Android 10.

### Related Issues

#80 #88

